### PR TITLE
Update .gitignore to ignore files generated by jdtls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ src/test/data/sandbox/
 .DS_Store
 docs/_site/
 docs/_markbind/logs/
+
+# nvim lsp generated files
+.classpath
+.project
+/.settings/
+/bin/


### PR DESCRIPTION
My ide uses jdts for linting and it ends up autogenerating some files that i do not wish to be committed.