### PR TITLE
Implement `meeting-contacts` command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -22,7 +22,8 @@ public class Messages {
                 "Multiple values specified for the following single-valued field(s): ";
 
     public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is invalid";
-
+    public static final String MESSAGE_GENERIC_INDEX_OUT_OF_BOUNDS =
+            "Index provided is out of bounds\n%1$s";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/MeetingContactsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MeetingContactsCommand.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_GENERIC_INDEX_OUT_OF_BOUNDS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_UID;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.model.Model;
+import seedu.address.model.person.FieldContainsKeywordsPredicate;
+
+/**
+ * Lists all contacts of a meeting.
+ */
+public class MeetingContactsCommand extends Command {
+    public static final String COMMAND_WORD = "meeting-contacts";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": View contacts of this meeting.\n"
+            + "Parameters: INDEX"
+            + "Example: " + COMMAND_WORD + " 2";
+
+    private final Index targetMeetingIndex;
+
+    public MeetingContactsCommand(Index targetMeetingIndex) {
+        this.targetMeetingIndex = targetMeetingIndex;
+    }
+
+    /**
+     * Uses {@code FindCommand} to find the contacts of a meeting.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return the result of the command
+     * @throws CommandException If the index is out of bounds.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        // check if the index is out of bounds
+        if (model.getWeeklySchedule().size() <= targetMeetingIndex.getZeroBased()
+                || targetMeetingIndex.getZeroBased() < 0) {
+            throw new CommandException(String.format(MESSAGE_GENERIC_INDEX_OUT_OF_BOUNDS,
+                    MESSAGE_USAGE));
+        }
+
+        ArgumentMultimap argumentMultimap = new ArgumentMultimap();
+        // assert that meeting has contacts
+        // if contacts field becomes optional remove this assertion
+        assert(!model.getMeeting(targetMeetingIndex).getContactUids().isEmpty());
+        model.getMeeting(targetMeetingIndex).getContactUids().stream()
+            .forEach(uid -> argumentMultimap.put(PREFIX_UID, uid.toString()));
+        return new FindCommand(new FieldContainsKeywordsPredicate(argumentMultimap))
+                .execute(model);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MeetingContactsCommand;
 import seedu.address.logic.commands.SeeAllScheduleCommand;
 import seedu.address.logic.commands.SeeScheduleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -97,6 +98,8 @@ public class AddressBookParser {
         case DeleteScheduleCommand.COMMAND_WORD:
             return new DeleteScheduleCommandParser().parse(arguments);
 
+        case MeetingContactsCommand.COMMAND_WORD:
+            return new MeetingContactsCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,5 +14,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_CONTACT = new Prefix("c/");
     public static final Prefix PREFIX_DATE = new Prefix("d/");
     public static final Prefix PREFIX_TIME = new Prefix("t/");
-
+    public static final Prefix PREFIX_UID = new Prefix("u/");
 }

--- a/src/main/java/seedu/address/logic/parser/MeetingContactsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MeetingContactsCommandParser.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_GENERIC_INDEX_OUT_OF_BOUNDS;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.MeetingContactsCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new MeetingContactsCommand object
+ */
+public class MeetingContactsCommandParser implements Parser<MeetingContactsCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MeetingContactsCommand
+     * @throws ParseException if the user input does not conform the expected
+     */
+    public MeetingContactsCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+        if (args.isEmpty() || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    MeetingContactsCommand.MESSAGE_USAGE));
+        }
+        try {
+            return new MeetingContactsCommand(Index
+                    .fromOneBased(Integer.valueOf(argMultimap.getPreamble())));
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    MeetingContactsCommand.MESSAGE_USAGE));
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_GENERIC_INDEX_OUT_OF_BOUNDS,
+                    MeetingContactsCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Person;
 import seedu.address.model.schedule.Meeting;
 
@@ -97,7 +98,15 @@ public interface Model {
     ObservableList<Meeting> getWeeklySchedule();
 
     void changeWeeklySchedule(Predicate<Meeting> predicate);
+
     ObservableList<Meeting> getCurrentWeeklySchedule(Predicate<Meeting> predicate);
+
+    /**
+     * @param i Index of the meeting to be retrieved
+     * @return The meeting at the given index with respect to the currently displayed
+     *     weekly schedule
+     */
+    Meeting getMeeting(Index i);
 
     /**
      * Returns an unmodifiable view of the filtered person list

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Person;
 import seedu.address.model.schedule.Meeting;
 
@@ -238,4 +239,8 @@ public class ModelManager implements Model {
         return weeklySchedule;
     }
 
+    @Override
+    public Meeting getMeeting(Index i) {
+        return weeklySchedule.get(i.getZeroBased());
+    }
 }

--- a/src/main/java/seedu/address/model/person/FieldContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FieldContainsKeywordsPredicate.java
@@ -2,10 +2,12 @@ package seedu.address.model.person;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Predicate;
 
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.Prefix;
+import seedu.address.storage.JsonAdaptedMeeting;
 
 /**
  * Tests that a {@code Person}'s fields matches any of the keywords given.
@@ -25,29 +27,36 @@ public class FieldContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         Set<Prefix> prefixes = argMultimap.getPrefixes();
-        Boolean result = false;
+        Boolean isMatch = false;
         for (Prefix prefix : prefixes) {
             List<String> keywords = argMultimap.getAllValues(prefix);
             switch (prefix.getPrefix()) {
 
             case "n/":
-                result = keywords.stream()
+                isMatch = keywords.stream()
                         .anyMatch(keyword -> person.nameContainsKeyword(keyword));
                 break;
 
             case "t/":
-                result = keywords.stream()
+                isMatch = keywords.stream()
                         .anyMatch(keyword -> person.hasTag(keyword));
+                break;
+
+            case "u/":
+                assert(keywords.stream().allMatch(keyword -> keyword
+                        .matches(JsonAdaptedMeeting.UIDREGEX)));
+                isMatch = keywords.stream()
+                    .anyMatch(keyword -> person.isSamePersonUid(UUID.fromString(keyword)));
                 break;
 
             default:
                 break;
             }
-            if (result) {
+            if (isMatch) {
                 break;
             }
         }
-        return result;
+        return isMatch;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -115,6 +115,15 @@ public class Person {
     }
 
     /**
+     * This defines a weaker notion of equality between two persons based on UUID.
+     * @param uid The UUID to compare with.
+     * @return True if the UUID is the same as the person's UUID.
+     */
+    public boolean isSamePersonUid(UUID uid) {
+        return this.uid.equals(uid);
+    }
+
+    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
@@ -204,6 +205,11 @@ public class AddCommandTest {
 
         @Override
         public boolean hasPersonInMeeting(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Meeting getMeeting(Index i) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
This pull request introduces a new feature to list all contacts of a meeting, along with some related code improvements and additions. The most important changes include adding the `MeetingContactsCommand`, updating the parser to handle the new command, and enhancing the `Model` interface and its implementation.

### New Feature: Meeting Contacts Command

* [`src/main/java/seedu/address/logic/commands/MeetingContactsCommand.java`](diffhunk://#diff-28451b5715c58421ef0797034c17269e0c542cd19cedfb0baf065f74e9beb3b2R1-R55): Introduced `MeetingContactsCommand` to list all contacts of a specified meeting. This includes validation for index bounds and integration with the `FindCommand`.

### Parser Updates

* [`src/main/java/seedu/address/logic/parser/AddressBookParser.java`](diffhunk://#diff-399c284cb892c20b7c04a69116fcff6ccc0666c5230a1db8e4a9145def8fa4eeR23): Added `MeetingContactsCommand` to the command parser to handle user input for the new command. [[1]](diffhunk://#diff-399c284cb892c20b7c04a69116fcff6ccc0666c5230a1db8e4a9145def8fa4eeR23) [[2]](diffhunk://#diff-399c284cb892c20b7c04a69116fcff6ccc0666c5230a1db8e4a9145def8fa4eeR101-R102)
* [`src/main/java/seedu/address/logic/parser/MeetingContactsCommandParser.java`](diffhunk://#diff-ae2d3061d9581b86a3a768e8b15d4d58d12fd26a365136fddaaaac95a6c0ee5dR1-R36): Created `MeetingContactsCommandParser` to parse arguments and create `MeetingContactsCommand` objects.

### Model Enhancements

* [`src/main/java/seedu/address/model/Model.java`](diffhunk://#diff-cde5cc4d986f48bcc473feff59dc96b93b494e15b3e309f36b7afd17109eeb05R101-R110): Added `getMeeting` method to retrieve a meeting by index from the weekly schedule.
* [`src/main/java/seedu/address/model/ModelManager.java`](diffhunk://#diff-7bd09b3a54ed83a93060f9d5e74302f5affc224dd83cb8ae73eafa10a999930dR242-R245): Implemented the `getMeeting` method in `ModelManager`.

### Other Changes

* [`src/main/java/seedu/address/logic/Messages.java`](diffhunk://#diff-bec7c0a95c73b355be29625e1096c8ca3a94cca13df1aa57d1b7f23ea54b4cbdL25-R26): Added a generic index out-of-bounds message for better error handling.
* [`src/main/java/seedu/address/logic/parser/CliSyntax.java`](diffhunk://#diff-849644283862aaa96d9509f38908cfb4b37caa440a9defc53ca476b4ad265394L17-R17): Added a new prefix `u/` for user IDs.
* [`src/main/java/seedu/address/model/person/FieldContainsKeywordsPredicate.java`](diffhunk://#diff-d4a0a479836ad6ffc04193b4b01fb998985f889eabdb5bd0779c94c39ffc5f09L28-R59): Enhanced to handle matching based on user IDs.
* [`src/main/java/seedu/address/model/person/Person.java`](diffhunk://#diff-14224fb2565ee7f6edae14d5b9f63d45dc8e0b7f2ad83f9d601f2f1116b40657R117-R125): Added a method to compare persons based on UUID.
* [`src/test/java/seedu/address/logic/commands/AddCommandTest.java`](diffhunk://#diff-b36041d808ad100ab736dfb2e71a3a86faf4d1f01350997b77ba595fccf293ffR210-R214): Updated test stubs to include the new `getMeeting` method.

### Command Preview
https://github.com/user-attachments/assets/06979571-5320-4bc3-8bd9-04cda644cf21