### PR TITLE
Fix empty addressbook attempting to create sample schedule list

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -106,8 +106,12 @@ public class MainApp extends Application {
                 logger.info("Creating a new data file " + scheduleStorage.getScheduleListFilePath()
                         + " populated with a sample ScheduleList.");
             }
-            initialScheduleList = scheduleListOptional
-                    .orElse(SampleDataUtil.getSampleScheduleList(initialData));
+            if (initialData.getPersonList().isEmpty()) {
+                initialScheduleList = new ScheduleList();
+            } else {
+                initialScheduleList = scheduleListOptional
+                        .orElse(SampleDataUtil.getSampleScheduleList(initialData));
+            }
             if (JsonSerializableScheduleStorage.hasErrorConvertingToModelType()) {
                 scheduleStorage.handleCorruptedFile();
             }


### PR DESCRIPTION
see #101

This pull request includes a change to the `MainApp` class to handle the initialization of the `ScheduleList` more robustly. Specifically, it ensures that an empty `ScheduleList` is created if the `PersonList` is empty and sample `ScheduleList` is created when no `schedule.json` exists and addressbook is non-empty.

Improvements to initialization logic:

* [`src/main/java/seedu/address/MainApp.java`](diffhunk://#diff-5b1e7db9083d3e90ee966e3646c0fb21aad4881e163dcbd53b0e038dc909b750R109-R114): Added a check to create an empty `ScheduleList` if `initialData.getPersonList()` is empty, ensuring that the application handles cases where there is no initial person data more gracefully.

## possible future improvements
schedule list sample data __should only__ be created together with addressbook sample data