### PR TITLE
Fix `see` command not catching datetimeparse exceptions

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -41,7 +41,7 @@ import seedu.address.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(0, 2, 2, true);
+    public static final Version VERSION = new Version(1, 2, 0, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 

--- a/src/main/java/seedu/address/logic/commands/SeeScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SeeScheduleCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.schedule.SameWeekAsDatePredicate;
 public class SeeScheduleCommand extends Command {
     public static final String COMMAND_WORD = "see";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": See your schedule for the week. "
-            + "Parameters: d/\n"
+            + "Parameters: d/dd-MM-YYYY\n"
             + "Example: " + COMMAND_WORD + " d/10-10-2024";
 
     public static final String MESSAGE_INVALID_DATE = "Date must be in the format DD-MM-YYYY.";

--- a/src/main/java/seedu/address/logic/parser/SeeScheduleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SeeScheduleCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import seedu.address.logic.commands.SeeScheduleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -28,12 +29,13 @@ public class SeeScheduleCommandParser implements Parser<SeeScheduleCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SeeScheduleCommand.MESSAGE_USAGE));
         }
-
-        LocalDate date = LocalDate.parse(argMultimap.getValue(PREFIX_DATE).get(),
-                DateTimeFormatter.ofPattern("dd-MM-yyyy"));
-        return new SeeScheduleCommand(new SameWeekAsDatePredicate(date));
-
+        try {
+            LocalDate date = LocalDate.parse(argMultimap.getValue(PREFIX_DATE).get(),
+                    DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+            return new SeeScheduleCommand(new SameWeekAsDatePredicate(date));
+        } catch (DateTimeParseException e) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SeeScheduleCommand.MESSAGE_USAGE));
+        }
     }
-
-
 }


### PR DESCRIPTION
see #138 oops i branched from my other PR

This pull request aim to improve date parsing functionality and update the application version.

### SeeScheduleCommand enhancements:
* Updated the `MESSAGE_USAGE` to specify the date format as `d/dd-MM-YYYY` for better clarity.

### SeeScheduleCommandParser improvements:
* Added `DateTimeParseException` import to handle invalid date formats.
* Enhanced the `parse` method to catch `DateTimeParseException` and throw a `ParseException` with a user-friendly message.