### PR TITLE
Fix GUI not separating different contacts in schedule

### DIFF
--- a/src/main/java/seedu/address/ui/calendar/CalendarCard.java
+++ b/src/main/java/seedu/address/ui/calendar/CalendarCard.java
@@ -3,9 +3,9 @@ package seedu.address.ui.calendar;
 import javafx.collections.transformation.FilteredList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 import seedu.address.model.schedule.Meeting;
@@ -30,7 +30,7 @@ public class CalendarCard extends UiPart<Region> {
     @FXML
     private Label time;
     @FXML
-    private FlowPane associatedContacts;
+    private VBox associatedContacts;
 
     /**
      * Creates a {@code CalendarCard} with the given {@code meeting} and index to display.

--- a/src/main/resources/view/CalendarListCard.fxml
+++ b/src/main/resources/view/CalendarListCard.fxml
@@ -27,7 +27,7 @@
                 </Label>
                 <Label fx:id="event" text="\$first" styleClass="cell_big_label" />
             </HBox>
-            <FlowPane fx:id="associatedContacts" />
+            <VBox fx:id="associatedContacts" spacing="1"/>
             <Label fx:id="date" styleClass="cell_small_label" text="\$date" />
             <Label fx:id="time" styleClass="cell_small_label" text="\$time" />
         </VBox>


### PR DESCRIPTION
see #133 

https://github.com/user-attachments/assets/2b3a3b05-9b01-4aa5-abd7-da56a7ab5a40

This pull request involves changes to the `CalendarCard` component to improve the layout and structure of the associated contacts section. The most important changes include replacing `FlowPane` with `VBox` for better vertical alignment and spacing.

Changes to `CalendarCard` component:

* [`src/main/java/seedu/address/ui/calendar/CalendarCard.java`](diffhunk://#diff-eb726892e45f6af813028ae189d4713304042fb0ff377f90c14879d5d5b0746eL6-R8): Replaced `FlowPane` with `VBox` for the `associatedContacts` field to improve layout. [[1]](diffhunk://#diff-eb726892e45f6af813028ae189d4713304042fb0ff377f90c14879d5d5b0746eL6-R8) [[2]](diffhunk://#diff-eb726892e45f6af813028ae189d4713304042fb0ff377f90c14879d5d5b0746eL33-R33)
* [`src/main/resources/view/CalendarListCard.fxml`](diffhunk://#diff-0aa84b61bda62ead19e5249df1aa7de58aa127601193ac7f14fc0205e26e642aL30-R30): Updated the `associatedContacts` element from `FlowPane` to `VBox` with a spacing of 1.