### PR TITLE
Test coverage for seeschedule, seeallschedule, and addressbookparser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SeeAllScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SeeAllScheduleCommand.java
@@ -21,4 +21,10 @@ public class SeeAllScheduleCommand extends Command {
         model.changeWeeklySchedule(PREDICATE_SHOW_ALL_MEETINGS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || other instanceof SeeAllScheduleCommand; // instanceof handles
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/SeeScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SeeScheduleCommand.java
@@ -31,13 +31,17 @@ public class SeeScheduleCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE dd-MM-yyyy");
-        System.out.println(predicate.getStartDateOfWeek());
-        System.out.println(predicate.getStartDateOfWeek().format(formatter));
-
         model.changeWeeklySchedule(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_SCHEDULE_LISTED_OVERVIEW,
                         predicate.getStartDateOfWeek().format(formatter),
                         predicate.getLastDateOfWeek().format(formatter)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SeeScheduleCommand // instanceof handles nulls
+                && predicate.equals(((SeeScheduleCommand) other).predicate)); // state check
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SeeAllScheduleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SeeAllScheduleCommandTest.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalMeetings.getTypicalMeetings;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class SeeAllScheduleCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(),
+            new UserPrefs(), getTypicalMeetings());
+
+    @Test
+    public void execute_success() {
+        SeeAllScheduleCommand command = new SeeAllScheduleCommand();
+        CommandResult expectedCommandResult = new CommandResult(
+                SeeAllScheduleCommand.MESSAGE_SUCCESS);
+        assertCommandSuccess(command, model, expectedCommandResult, model);
+        assertEquals(3, model.getScheduleList().getMeetingList().size());
+    }
+
+    @Test
+    public void equals() {
+        SeeAllScheduleCommand firstCommand = new SeeAllScheduleCommand();
+        SeeAllScheduleCommand secondCommand = new SeeAllScheduleCommand();
+        // same object -> returns true
+        assertEquals(firstCommand, firstCommand);
+        // same values -> returns true
+        assertEquals(firstCommand, secondCommand);
+        // different types -> returns false
+        assertNotEquals(1, firstCommand);
+        // null -> returns false
+        assertNotEquals(null, firstCommand);
+        // completely different command -> returns false
+        assertNotEquals(firstCommand, new ListCommand());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SeeScheduleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SeeScheduleCommandTest.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalMeetings.getTypicalMeetings;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.schedule.SameWeekAsDatePredicate;
+
+public class SeeScheduleCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(),
+            new UserPrefs(), getTypicalMeetings());
+
+    @Test
+    public void execute_success() {
+        SameWeekAsDatePredicate predicate = new SameWeekAsDatePredicate(LocalDate
+                .parse("2024-11-05"));
+        SeeScheduleCommand seeScheduleCommand = new SeeScheduleCommand(predicate);
+        CommandResult expectedCommandResult = new CommandResult(
+                String.format(Messages.MESSAGE_SCHEDULE_LISTED_OVERVIEW,
+                "Sun 03-11-2024", "Sat 09-11-2024"));
+        assertCommandSuccess(seeScheduleCommand, model, expectedCommandResult, model);
+        assertEquals(2, model.getWeeklySchedule().filtered(predicate).size());
+    }
+
+    @Test
+    public void equals() {
+        SameWeekAsDatePredicate firstPredicate = new SameWeekAsDatePredicate(LocalDate
+                .parse("2024-11-05"));
+        SameWeekAsDatePredicate secondPredicate = new SameWeekAsDatePredicate(LocalDate
+                .parse("2024-11-06"));
+        SeeScheduleCommand seeFirstCommand = new SeeScheduleCommand(firstPredicate);
+        SeeScheduleCommand seeSecondCommand = new SeeScheduleCommand(secondPredicate);
+        // same object -> returns true
+        assertEquals(seeFirstCommand, seeFirstCommand);
+        // same values -> returns true
+        SeeScheduleCommand seeFirstCommandCopy = new SeeScheduleCommand(firstPredicate);
+        assertEquals(seeFirstCommand, seeFirstCommandCopy);
+        // different types -> returns false
+        assertNotEquals(1, seeFirstCommand);
+        // null -> returns false
+        assertNotEquals(null, seeFirstCommand);
+        // different person -> returns false
+        assertNotEquals(seeFirstCommand, seeSecondCommand);
+        // completely different command -> returns false
+        assertNotEquals(seeFirstCommand, new ListCommand());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -8,24 +8,36 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteScheduleCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditScheduleCommand;
+import seedu.address.logic.commands.EditScheduleCommand.EditScheduleDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FavouriteCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MeetingContactsCommand;
+import seedu.address.logic.commands.SeeAllScheduleCommand;
+import seedu.address.logic.commands.SeeScheduleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.FieldContainsKeywordsPredicate;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.schedule.SameWeekAsDatePredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -94,6 +106,50 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_meetingContacts() throws Exception {
+        String userInput = MeetingContactsCommand.COMMAND_WORD + " 1";
+        assertEquals(new MeetingContactsCommand(Index.fromOneBased(1)),
+                (MeetingContactsCommand) parser.parseCommand(userInput));
+    }
+
+    @Test
+    public void parseCommand_seeSchedule() throws Exception {
+        String userInput = SeeScheduleCommand.COMMAND_WORD + " d/05-11-2024";
+        assertEquals(new SeeScheduleCommand(new SameWeekAsDatePredicate(LocalDate
+                .parse("2024-11-05"))), (SeeScheduleCommand) parser.parseCommand(userInput));
+    }
+
+    @Test void parseCommand_seeAllSchedule() throws Exception {
+        assertEquals(new SeeAllScheduleCommand(),
+            (SeeAllScheduleCommand) parser.parseCommand(SeeAllScheduleCommand.COMMAND_WORD));
+    }
+
+    @Test
+    public void parseCommand_favourite() throws Exception {
+        String userInput = FavouriteCommand.COMMAND_WORD + " c/1 2";
+        assertEquals(new FavouriteCommand(List.of(Index.fromOneBased(1), Index.fromOneBased(2))),
+                (FavouriteCommand) parser.parseCommand(userInput));
+    }
+
+    @Test
+    public void parseCommand_deleteSchedule() throws Exception {
+        String userInput = DeleteScheduleCommand.COMMAND_WORD + " 1";
+        assertEquals(new DeleteScheduleCommand(Index.fromOneBased(1)),
+                (DeleteScheduleCommand) parser.parseCommand(userInput));
+    }
+
+    @Test
+    public void parseCommand_editSchedule() throws Exception {
+        EditScheduleDescriptor descriptor = new EditScheduleDescriptor();
+        descriptor.setName(new Name("Dinner"));
+        descriptor.setDate(LocalDate.parse("2024-10-10"));
+        descriptor.setTime(LocalTime.parse("18:00"));
+        String userInput = EditScheduleCommand.COMMAND_WORD + " 1 n/Dinner d/10-10-2024 t/1800";
+        assertEquals(new EditScheduleCommand(Index.fromOneBased(1), descriptor),
+                (EditScheduleCommand) parser.parseCommand(userInput));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SeeScheduleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SeeScheduleCommandParserTest.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SeeScheduleCommand;
+import seedu.address.model.schedule.SameWeekAsDatePredicate;
+
+public class SeeScheduleCommandParserTest {
+
+    private final SeeScheduleCommandParser parser = new SeeScheduleCommandParser();
+
+    @Test
+    public void parse_validArgs_success() {
+        assertParseSuccess(parser, " d/05-11-2024", new SeeScheduleCommand(
+                new SameWeekAsDatePredicate(LocalDate.parse("2024-11-05"))));
+    }
+
+    @Test
+    public void parse_invalidArgs_failure() {
+        assertParseFailure(parser, "", String
+                .format(MESSAGE_INVALID_COMMAND_FORMAT, SeeScheduleCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " ", String
+                .format(MESSAGE_INVALID_COMMAND_FORMAT, SeeScheduleCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " d/01-31-2024", String
+                .format(MESSAGE_INVALID_COMMAND_FORMAT, SeeScheduleCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " d/1-1-2024", String
+                .format(MESSAGE_INVALID_COMMAND_FORMAT, SeeScheduleCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " 05-11-2024", String
+                .format(MESSAGE_INVALID_COMMAND_FORMAT, SeeScheduleCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
This pull request includes enhancements and tests for the `SeeAllScheduleCommand` and `SeeScheduleCommand` classes, along with updates to the `AddressBookParserTest` and the addition of `SeeScheduleCommandParserTest`.

### Enhancements to Commands:

* Added `equals` method to `SeeAllScheduleCommand` for proper equality checks.
* Added `equals` method to `SeeScheduleCommand` for proper equality checks.

### Test Additions:

* Created `SeeAllScheduleCommandTest` to verify the functionality and equality of `SeeAllScheduleCommand`.
* Created `SeeScheduleCommandTest` to verify the functionality and equality of `SeeScheduleCommand`.

### Parser Tests:

* Updated `AddressBookParserTest` to include tests for new commands: `SeeAllScheduleCommand`, `SeeScheduleCommand`, `MeetingContactsCommand`, `FavouriteCommand`, `DeleteScheduleCommand`, and `EditScheduleCommand`. [[1]](diffhunk://#diff-e6399ba0e95a3c101d6cfc7cab0eb7d487b7462ae1bf2dea7a1323b27c59f391R11-R40) [[2]](diffhunk://#diff-e6399ba0e95a3c101d6cfc7cab0eb7d487b7462ae1bf2dea7a1323b27c59f391R111-R154)
* Added `SeeScheduleCommandParserTest` to validate argument parsing for `SeeScheduleCommand`.