### PR TITLE
Add ignore ui codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "scr/main/java/seedu/address/ui"


### PR DESCRIPTION
This pull request includes a small change to the `codecov.yml` file. The change adds a new ignore rule to exclude files in the `scr/main/java/seedu/address/ui` directory from code coverage analysis.