### PR TITLE
Test coverage for jsonschedulestorage and storagemanager

### DIFF
--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -100,7 +100,7 @@ public class StorageManager implements Storage {
 
     @Override
     public void saveScheduleList(ReadOnlyScheduleList scheduleList) throws IOException {
-        saveScheduleList(scheduleList, addressBookStorage.getAddressBookFilePath());
+        saveScheduleList(scheduleList, getScheduleListFilePath());
     }
 
     @Override

--- a/src/test/data/JsonScheduleStorageTest/invalidEntriesMeetingsSchedule.json
+++ b/src/test/data/JsonScheduleStorageTest/invalidEntriesMeetingsSchedule.json
@@ -1,0 +1,17 @@
+{
+  "meetings" : [ {
+    "contactIndexes" : "11111111-1111-1111-1111-111111111111,22222222-2222-2222-2222-222222222222",
+    "meetingDate" : "2024-11-01",
+    "meetingTime" : "10:00:00"
+  }, {
+    "meetingName" : "Project Discussion",
+    "meetingDate" : "2024-11-03",
+    "meetingTime" : "14:30:00"
+  }, {
+    "contactIndexes" : "66666666-6666-6666-6666-666666666666,77777777-7777-7777-7777-777777777777",
+    "meetingName" : "Client Review",
+    "meetingDate" : "2024-11-05",
+    "meetingTime" : "16:00:00"
+  } ]
+}
+

--- a/src/test/data/JsonScheduleStorageTest/notJsonFormatSchedule.json
+++ b/src/test/data/JsonScheduleStorageTest/notJsonFormatSchedule.json
@@ -1,0 +1,1 @@
+not json format!

--- a/src/test/java/seedu/address/storage/JsonScheduleStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonScheduleStorageTest.java
@@ -1,0 +1,114 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalMeetings.TEAM_SYNC;
+import static seedu.address.testutil.TypicalMeetings.TEAM_SYNC_1;
+import static seedu.address.testutil.TypicalMeetings.TEAM_SYNC_2;
+import static seedu.address.testutil.TypicalMeetings.getTypicalMeetings;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.address.commons.exceptions.DataLoadingException;
+import seedu.address.model.ReadOnlyScheduleList;
+import seedu.address.model.ScheduleList;
+
+public class JsonScheduleStorageTest {
+
+    private final Path TEST_DATA_FOLDER = Paths
+            .get("src", "test", "data", "JsonScheduleStorageTest");
+
+    @TempDir
+    public Path testFolder;
+
+    private java.util.Optional<ReadOnlyScheduleList> readScheduleList(String filePath) throws Exception {
+        return new JsonScheduleStorage(Paths.get(filePath))
+                .readScheduleList(TEST_DATA_FOLDER.resolve(filePath));
+    }
+
+    private Path addToTestDataPathIfNotNull(String prefsFileInTestDataFolder) {
+        return prefsFileInTestDataFolder != null
+                ? TEST_DATA_FOLDER.resolve(prefsFileInTestDataFolder)
+                : null;
+    }
+
+    @Test
+    public void readScheduleList_nullFilePath_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> readScheduleList(null));
+    }
+
+    @Test
+    public void read_missingFile_emptyResult() throws Exception {
+        assertFalse(readScheduleList("NonExistentFile.json").isPresent());
+    }
+
+    @Test
+    public void read_notJsonFormat_exceptionThrown() {
+        assertThrows(DataLoadingException.class, () -> 
+                readScheduleList("notJsonFormatSchedule.json"));
+    }
+
+    @Test
+    public void read_allInOrder_success() throws Exception {
+        Path filePath = testFolder.resolve("TempSchedule.json");
+        ScheduleList original = (ScheduleList) getTypicalMeetings();
+        JsonScheduleStorage jsonScheduleStorage = new JsonScheduleStorage(filePath);
+
+        // Save in new file and read back
+        jsonScheduleStorage.saveScheduleList(original, filePath);
+        ReadOnlyScheduleList readBack = jsonScheduleStorage.readScheduleList(filePath).get();
+        assertEquals(original, new ScheduleList(readBack));
+
+        // Modify data, overwrite exiting file, and read back
+        original.addMeeting(TEAM_SYNC_1);
+        original.removeMeeting(TEAM_SYNC);
+        jsonScheduleStorage.saveScheduleList(original, filePath);
+        readBack = jsonScheduleStorage.readScheduleList(filePath).get();
+        assertEquals(original, new ScheduleList(readBack));
+
+        // Save and read without specifying file path
+        original.addMeeting(TEAM_SYNC_2);
+        jsonScheduleStorage.saveScheduleList(original); // file path not specified
+        readBack = jsonScheduleStorage.readScheduleList().get(); // file path not specified
+        assertEquals(original, new ScheduleList(readBack));
+    }
+
+    @Test
+    public void getScheduleListFilePath() {
+        Path filePath = testFolder.resolve("TempSchedule.json");
+        JsonScheduleStorage jsonScheduleStorage = new JsonScheduleStorage(filePath);
+        assertEquals(filePath, jsonScheduleStorage.getScheduleListFilePath());
+    }
+
+    @Test
+    public void handleCorruptedFile() throws Exception {
+        Path filePath = TEST_DATA_FOLDER.resolve("invalidEntriesMeetingsSchedule.json");
+        JsonScheduleStorage jsonScheduleStorage = new JsonScheduleStorage(filePath);
+        jsonScheduleStorage.handleCorruptedFile();
+        boolean hasBakFile = false;
+        Stream<Path> files = Files.list(TEST_DATA_FOLDER);
+        Iterator<Path> iter = files.iterator();
+        Path bakFile = null;
+        while (iter.hasNext()) {
+            Path file = iter.next();
+            if (Pattern.matches(".*invalidEntriesMeetingsSchedule.json.*.bak", file.toString())) {
+                hasBakFile = true;
+                bakFile = file;
+            }
+        }
+        files.close();
+        assertTrue(hasBakFile);
+        bakFile.toFile().delete();
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonScheduleStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonScheduleStorageTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalMeetings.TEAM_SYNC_1;
 import static seedu.address.testutil.TypicalMeetings.TEAM_SYNC_2;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetings;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -26,26 +25,20 @@ import seedu.address.model.ScheduleList;
 
 public class JsonScheduleStorageTest {
 
-    private final Path TEST_DATA_FOLDER = Paths
+    private static final Path TEST_DATA_FOLDER = Paths
             .get("src", "test", "data", "JsonScheduleStorageTest");
 
     @TempDir
     public Path testFolder;
 
-    private java.util.Optional<ReadOnlyScheduleList> readScheduleList(String filePath) throws Exception {
-        return new JsonScheduleStorage(Paths.get(filePath))
-                .readScheduleList(TEST_DATA_FOLDER.resolve(filePath));
-    }
-
-    private Path addToTestDataPathIfNotNull(String prefsFileInTestDataFolder) {
-        return prefsFileInTestDataFolder != null
-                ? TEST_DATA_FOLDER.resolve(prefsFileInTestDataFolder)
-                : null;
-    }
-
     @Test
     public void readScheduleList_nullFilePath_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> readScheduleList(null));
+    }
+
+    private java.util.Optional<ReadOnlyScheduleList> readScheduleList(String filePath) throws Exception {
+        return new JsonScheduleStorage(Paths.get(filePath))
+                .readScheduleList(TEST_DATA_FOLDER.resolve(filePath));
     }
 
     @Test
@@ -55,7 +48,7 @@ public class JsonScheduleStorageTest {
 
     @Test
     public void read_notJsonFormat_exceptionThrown() {
-        assertThrows(DataLoadingException.class, () -> 
+        assertThrows(DataLoadingException.class, () ->
                 readScheduleList("notJsonFormatSchedule.json"));
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -52,7 +52,7 @@ public class StorageManagerTest {
         storageManager.saveUserPrefs(original);
         UserPrefs retrieved = storageManager.readUserPrefs().get();
         assertEquals(original, retrieved);
-        assertTrue(Pattern.matches("/tmp/junit\\d+/prefs", 
+        assertTrue(Pattern.matches("/tmp/junit\\d+/prefs",
                 storageManager.getUserPrefsFilePath().toString()));
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -52,7 +52,7 @@ public class StorageManagerTest {
         storageManager.saveUserPrefs(original);
         UserPrefs retrieved = storageManager.readUserPrefs().get();
         assertEquals(original, retrieved);
-        assertTrue(Pattern.matches("/tmp/junit\\d+/prefs",
+        assertTrue(Pattern.matches(".*prefs",
                 storageManager.getUserPrefsFilePath().toString()));
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -1,10 +1,14 @@
 package seedu.address.storage;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalMeetings.getTypicalMeetings;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,6 +17,8 @@ import org.junit.jupiter.api.io.TempDir;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyScheduleList;
+import seedu.address.model.ScheduleList;
 import seedu.address.model.UserPrefs;
 
 public class StorageManagerTest {
@@ -46,6 +52,8 @@ public class StorageManagerTest {
         storageManager.saveUserPrefs(original);
         UserPrefs retrieved = storageManager.readUserPrefs().get();
         assertEquals(original, retrieved);
+        assertTrue(Pattern.matches("/tmp/junit\\d+/prefs", 
+                storageManager.getUserPrefsFilePath().toString()));
     }
 
     @Test
@@ -66,4 +74,20 @@ public class StorageManagerTest {
         assertNotNull(storageManager.getAddressBookFilePath());
     }
 
+    @Test
+    public void scheduleReadSave() throws Exception {
+        ReadOnlyScheduleList original = getTypicalMeetings();
+        storageManager.saveScheduleList(original);
+        ReadOnlyScheduleList retrieved = storageManager.readScheduleList().get();
+        assertEquals(original, new ScheduleList(retrieved));
+        retrieved = storageManager
+                .readScheduleList(storageManager.getScheduleListFilePath()).get();
+        assertEquals(original, new ScheduleList(retrieved));
+    }
+
+    @Test
+    public void handleCorruptedFiles() {
+        assertDoesNotThrow(storageManager::handleCorruptedFile);
+        assertDoesNotThrow(storageManager::handleCorruptedAddressbookFile);
+    }
 }


### PR DESCRIPTION
This pull request introduces several changes, primarily focusing on improving the handling and testing of schedule list storage in the application. The changes include updates to the `StorageManager` and `JsonScheduleStorage` classes, as well as the addition of new test cases and test data files.

### Schedule List Storage Enhancements:

* [`src/main/java/seedu/address/storage/StorageManager.java`](diffhunk://#diff-a424e066333d5655abe2f77beb944b17ed5f7bdceba631886375c95e48e97642L103-R103): Updated the `saveScheduleList` method to use `getScheduleListFilePath` instead of `addressBookStorage.getAddressBookFilePath`.

### Test Data Additions:

* [`src/test/data/JsonScheduleStorageTest/invalidEntriesMeetingsSchedule.json`](diffhunk://#diff-d77d39bd85a0edcd70f39b1eb178b08ffa8b2ec66f4b0941299d3b2a57a1386bR1-R17): Added a new JSON file with invalid meeting entries for testing purposes.
* [`src/test/data/JsonScheduleStorageTest/notJsonFormatSchedule.json`](diffhunk://#diff-52130a4ab011a0746ba5a88dd93c0e58c724d5a6007f7fac6c1ac51e3d15aad0R1): Added a new file with non-JSON content to test error handling.

### New Test Cases:

* [`src/test/java/seedu/address/storage/JsonScheduleStorageTest.java`](diffhunk://#diff-5c2edb540fb27272b66374632488d43b766c5e9f1199e591ea4432bba603e29fR1-R114): Added comprehensive test cases for `JsonScheduleStorage`, including tests for reading schedule lists, handling non-JSON formats, and managing corrupted files.

### Updates to Existing Tests:

* [`src/test/java/seedu/address/storage/StorageManagerTest.java`](diffhunk://#diff-a07c65e01fe0bfe0835246b513f8b95a58117d4f59697b36758e7008e3dbefdfR3-R11): Enhanced existing tests to include schedule list read/save operations and added assertions to validate file paths and handle corrupted files. [[1]](diffhunk://#diff-a07c65e01fe0bfe0835246b513f8b95a58117d4f59697b36758e7008e3dbefdfR3-R11) [[2]](diffhunk://#diff-a07c65e01fe0bfe0835246b513f8b95a58117d4f59697b36758e7008e3dbefdfR20-R21) [[3]](diffhunk://#diff-a07c65e01fe0bfe0835246b513f8b95a58117d4f59697b36758e7008e3dbefdfR55-R56) [[4]](diffhunk://#diff-a07c65e01fe0bfe0835246b513f8b95a58117d4f59697b36758e7008e3dbefdfR77-R92)