### PR TITLE
Update docs missing links to tutorial and aboutme page

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -28,8 +28,8 @@ You can reach us at the email `seer[at]comp.nus.edu.sg`
 [[github](https://github.com/LimKaiWei)]
 [[portfolio](team/limkaiwei.md)]
 
-* Role: ???
-* Responsibilities: ???
+* Role: Developer
+* Responsibilities: Backend
 
 ### Jewi Teo
 

--- a/docs/SettingUp.md
+++ b/docs/SettingUp.md
@@ -55,8 +55,8 @@ If you plan to use Intellij IDEA (highly recommended):
    When you are ready to start coding, we recommend that you get some sense of the overall design by reading about [AddressBook’s architecture](DeveloperGuide.md#architecture).
 
 1. **Do the tutorials**
-   These tutorials will help you get acquainted with the codebase.
+   These tutorials will help you get acquainted with the codebase. *These tutorials are curated by se-edu.*
 
-   * [Tracing code](tutorials/TracingCode.md)
-   * [Adding a new command](tutorials/AddRemark.md)
-   * [Removing fields](tutorials/RemovingFields.md)
+   * [Tracing code](https://se-education.org/guides/tutorials/ab3TracingCode.html)
+   * [Adding a new command](https://se-education.org/guides/tutorials/ab3AddRemark.html)
+   * [Removing fields](https://se-education.org/guides/tutorials/ab3RemovingFields.html)

--- a/docs/_markbind/layouts/default.md
+++ b/docs/_markbind/layouts/default.md
@@ -42,8 +42,8 @@
   * [Appendix: Instructions for manual testing]({{ baseUrl }}/DeveloperGuide.html#appendix-instructions-for-manual-testing)
 * [Tutorials](https://se-education.org/guides/tutorials/ab3.html)
   * [Tracing code](https://se-education.org/guides/tutorials/ab3TracingCode.html)
-  * [Adding a command]({{ baseUrl }}/tutorials/AddRemark.html)
-  * [Removing Fields]({{ baseUrl }}/tutorials/RemovingFields.html)
+  * [Adding a command](https://se-education.org/guides/tutorials/ab3AddRemark.html)
+  * [Removing Fields](https://se-education.org/guides/tutorials/ab3RemovingFields.html)
 * [About Us]({{ baseUrl }}/AboutUs.html)
       </site-nav>
     </div>

--- a/docs/_markbind/layouts/default.md
+++ b/docs/_markbind/layouts/default.md
@@ -40,8 +40,8 @@
   * [Documentation, logging, testing, configuration, dev-ops]({{ baseUrl }}/DeveloperGuide.html#documentation-logging-testing-configuration-dev-ops)
   * [Appendix: Requirements]({{ baseUrl }}/DeveloperGuide.html#appendix-requirements)
   * [Appendix: Instructions for manual testing]({{ baseUrl }}/DeveloperGuide.html#appendix-instructions-for-manual-testing)
-* Tutorials
-  * [Tracing code]({{ baseUrl }}/tutorials/TracingCode.html)
+* [Tutorials](https://se-education.org/guides/tutorials/ab3.html)
+  * [Tracing code](https://se-education.org/guides/tutorials/ab3TracingCode.html)
   * [Adding a command]({{ baseUrl }}/tutorials/AddRemark.html)
   * [Removing Fields]({{ baseUrl }}/tutorials/RemovingFields.html)
 * [About Us]({{ baseUrl }}/AboutUs.html)

--- a/docs/team/limkaiwei.md
+++ b/docs/team/limkaiwei.md
@@ -1,46 +1,33 @@
 ---
   layout: default.md
-  title: "John Doe's Project Portfolio Page"
+  title: "Lim Kai Wei's Project Portfolio Page"
 ---
 
-### Project: AddressBook Level 3
+### Project: SeeRee 2.0
 
-AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+SeeRee 2.0 is a combination of desktop address book and a scheduler for meetings application. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
 
 Given below are my contributions to the project.
 
-* **New Feature**: Added the ability to undo/redo previous commands.
-  * What it does: allows the user to undo all previous commands one at a time. Preceding undo commands can be reversed by using the redo command.
-  * Justification: This feature improves the product significantly because a user can make mistakes in commands and the app should provide a convenient way to rectify them.
-  * Highlights: This enhancement affects existing commands and commands to be added in future. It required an in-depth analysis of design alternatives. The implementation too was challenging as it required changes to existing commands.
-  * Credits: *{mention here if you reused any code/ideas from elsewhere or if a third-party library is heavily used in the feature so that a reader can make a more accurate judgement of how much effort went into the feature}*
+* **New Feature**: `meeting-contacts`
+  * What it does: allows user to filter and view contacts related to selected meetng.
 
-* **New Feature**: Added a history command that allows the user to navigate to previous commands using up/down keys.
-
-* **Code contributed**: [RepoSense link]()
-
-* **Project management**:
-  * Managed releases `v1.3` - `v1.5rc` (3 releases) on GitHub
+* **New Feature**: backup corrupted or broken save file
+  * What it does: allows automatic back up of corrupted or broken json save files for user to manually restore. 
+  * Justification: previously any corrupted entries will cause entire save file to be overwritten by an empty save. This will provide a way for users to retrieve any broken save files.
 
 * **Enhancements to existing features**:
-  * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())
-  * Wrote additional tests for existing features to increase coverage from 88% to 92% (Pull requests [\#36](), [\#38]())
+  * Enhanced `find` command searching by name and tag.
 
 * **Documentation**:
   * User Guide:
-    * Added documentation for the features `delete` and `find` [\#72]()
-    * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
+    * Added documentation for the features `meeting-contacts` and `find`.
   * Developer Guide:
-    * Added implementation details of the `delete` feature.
+    * Added implementation details of the `meeting-contacts` feature.
 
-* **Community**:
-  * PRs reviewed (with non-trivial review comments): [\#12](), [\#32](), [\#19](), [\#42]()
-  * Contributed to forum discussions (examples: [1](), [2](), [3](), [4]())
-  * Reported bugs and suggestions for other teams in the class (examples: [1](), [2](), [3]())
-  * Some parts of the history feature I added was adopted by several other class mates ([1](), [2]())
+* **Project management**:
+  * Managed releases `v1.0.0 - v1.2.0` (3 releases) on GitHub
 
-* **Tools**:
-  * Integrated a third party library (Natty) to the project ([\#42]())
-  * Integrated a new Github plugin (CircleCI) to the team repo
+* **Code contributed**: [RepoSense link](https://nus-cs2103-ay2425s1.github.io/tp-dashboard/?search=limkaiwei)
 
-* _{you can add/remove categories in the list above}_
+<iframe src="https://nus-cs2103-ay2425s1.github.io/tp-dashboard/#/widget/?search=limkai&sort=groupTitle&sortWithin=title&timeframe=commit&mergegroup=&groupSelect=groupByRepos&breakdown=true&checkedFileTypes=docs~functional-code~test-code~other&since=2024-09-20&tabOpen=true&tabType=zoom&zA=LimKaiWei&zR=AY2425S1-CS2103-F13-3%2Ftp%5Bmaster%5D&zACS=183.14285714285714&zS=2024-09-20&zFS=limkai&zU=2024-11-07&zMG=false&zFTF=commit&zFGS=groupByRepos&zFR=false&chartGroupIndex=0&chartIndex=0" frameBorder="0" width="800px" height="142px"></iframe>


### PR DESCRIPTION
This pull request includes updates to documentation files to reflect new roles, responsibilities, and project details, as well as improvements to tutorial links. The most important changes include updating team member roles, correcting tutorial links, and revising project contributions.

### Documentation Updates:

* [`docs/AboutUs.md`](diffhunk://#diff-4ba14c5782db9834e3144f2b7c21dd2f1f7fab11b70ff37031113dd104e11bbfL31-R32): Updated role and responsibilities for team member Lim Kai Wei.
* [`docs/team/limkaiwei.md`](diffhunk://#diff-2a65bb7d6b00ce60a19319c4715555e082f028e2ef417f09badeca0ff1bd4b4cL3-R33): Changed project details and contributions for Lim Kai Wei, including new features and enhancements.

### Tutorial Links:

* [`docs/SettingUp.md`](diffhunk://#diff-e4b0c86561f5b3a86020b494a454026e8812ee162eb374c8682a4b790e5c4e71L58-R62): Updated tutorial links to point to the correct URLs on the se-education website.
* [`docs/_markbind/layouts/default.md`](diffhunk://#diff-cc5ba9bdbfd8fed39b95d2a0d8e2786736d6af97bb968adc834c9102d60033f9L43-R46): Corrected tutorial links to reflect the updated URLs.