### PR TITLE
Fix test cases due to meeting conflict conditions changing

### DIFF
--- a/src/test/java/seedu/address/storage/JsonScheduleStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonScheduleStorageTest.java
@@ -64,13 +64,14 @@ public class JsonScheduleStorageTest {
         assertEquals(original, new ScheduleList(readBack));
 
         // Modify data, overwrite exiting file, and read back
-        original.addMeeting(TEAM_SYNC_1);
         original.removeMeeting(TEAM_SYNC);
+        original.addMeeting(TEAM_SYNC_1);
         jsonScheduleStorage.saveScheduleList(original, filePath);
         readBack = jsonScheduleStorage.readScheduleList(filePath).get();
         assertEquals(original, new ScheduleList(readBack));
 
         // Save and read without specifying file path
+        original.removeMeeting(TEAM_SYNC_1);
         original.addMeeting(TEAM_SYNC_2);
         jsonScheduleStorage.saveScheduleList(original); // file path not specified
         readBack = jsonScheduleStorage.readScheduleList().get(); // file path not specified


### PR DESCRIPTION
This pull request includes a small change to the `JsonScheduleStorageTest.java` file. The change modifies the order of operations in the `read_allInOrder_success` test method to ensure meetings are added and removed in the correct sequence for accurate testing.

Changes to `JsonScheduleStorageTest.java`:

* Modified the sequence of `addMeeting` and `removeMeeting` operations to ensure correct testing of the schedule list.