### PR TITLE
Add error message edit schedule when contact list is empty

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditScheduleCommand.java
@@ -37,6 +37,7 @@ public class EditScheduleCommand extends Command {
     public static final String MESSAGE_EDIT_SCHEDULE_SUCCESS = "Edited Event: %1$s";
     public static final String MESSAGE_INVALID_SCHEDULE_INDEX = "The schedule index provided is invalid.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_EMPTY_CONTACT_LIST = "You must have at least one contact in the schedule.";
 
     private final Index targetIndex; // The index of the schedule in the displayed schedule list
     private final EditScheduleDescriptor editScheduleDescriptor;
@@ -95,7 +96,10 @@ public class EditScheduleCommand extends Command {
                 Messages.formatMeetings(updatedMeeting)));
     }
 
-    private static List<UUID> getUpdatedContactUids(Meeting meetingToEdit, List<UUID> newContactUids) {
+    private static List<UUID> getUpdatedContactUids(
+            Meeting meetingToEdit,
+            List<UUID> newContactUids
+    ) throws CommandException {
         List<UUID> previousContactUids = meetingToEdit.getContactUids();
 
         List<UUID> updatedContactUids = new ArrayList<>();
@@ -110,8 +114,11 @@ public class EditScheduleCommand extends Command {
             }
         }
 
-        // check if updated contact list is empty, if so, revert to previous contact list
-        updatedContactUids = updatedContactUids.isEmpty() ? previousContactUids : updatedContactUids;
+        // Check if updated contact list is empty, if so, throw an exception
+        if (updatedContactUids.isEmpty()) {
+            throw new CommandException(MESSAGE_EMPTY_CONTACT_LIST);
+        }
+
         return updatedContactUids;
     }
 


### PR DESCRIPTION
This is added due to the actions failing silently as per the description in the course website.

![image](https://github.com/user-attachments/assets/40f768b2-1eed-49f0-b3e2-89eb9b08a88a)

![image](https://github.com/user-attachments/assets/fd212fa0-3b74-47ef-b09a-51f45d572639)


It was also due to a bug in the code in the feature implemented in v1.5 (commit 385530e4367ed0743de0c2b233effd4d248784e8), at EditScheduleCommand.java line 114.



