### PR TITLE
Fix `meeting-contacts` error message formatting not on new line typo

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MeetingContactsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MeetingContactsCommand.java
@@ -15,8 +15,8 @@ import seedu.address.model.person.FieldContainsKeywordsPredicate;
  */
 public class MeetingContactsCommand extends Command {
     public static final String COMMAND_WORD = "meeting-contacts";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": View contacts of this meeting.\n"
-            + "Parameters: INDEX"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": View contacts of this meeting. "
+            + "Parameters: INDEX\n"
             + "Example: " + COMMAND_WORD + " 2";
 
     private final Index targetMeetingIndex;


### PR DESCRIPTION
This pull request includes a small change to the `MeetingContactsCommand` class. The change modifies the `MESSAGE_USAGE` string to improve its readability by adjusting the line break placement.

* [`src/main/java/seedu/address/logic/commands/MeetingContactsCommand.java`](diffhunk://#diff-28451b5715c58421ef0797034c17269e0c542cd19cedfb0baf065f74e9beb3b2L18-R19): Adjusted the `MESSAGE_USAGE` string to place the line break after "Parameters: INDEX" for better readability.