### PR TITLE
Fix message formatting and not showing favourite set to true

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -54,10 +54,10 @@ public class Messages {
                 .append(person.getEmail())
                 .append("; Address: ")
                 .append(person.getAddress())
-                .append("; Tags: ")
-                .append("; favourite: ")
-                .append(person.getFavourite());
+                .append("; Tags: ");
         person.getTags().forEach(builder::append);
+        builder.append("; favourite: ")
+                .append(person.getFavourite());
         return builder.toString();
     }
 
@@ -75,10 +75,11 @@ public class Messages {
                     .append(person.getEmail())
                     .append("; Address: ")
                     .append(person.getAddress())
-                    .append("; Tags: ")
-                    .append("; favourite: ")
-                    .append(person.getFavourite());
+                    .append("; Tags: ");
             person.getTags().forEach(builder::append);
+            builder.append("; favourite: ")
+                    .append(person.getFavourite())
+                    .append("\n");
         }
         return builder.toString();
     }

--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSONS_INDEX;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,11 +44,13 @@ public class FavouriteCommand extends Command {
         List<Person> personsList = contactIndexes.stream()
             .map(index -> lastShownList.get(index.getZeroBased()))
             .collect(Collectors.toList());
+        List<Person> updatedPersonList = new ArrayList<Person>();
         for (Person p : personsList) {
             Person favouritePerson = createFavouritePerson(p);
             model.setPerson(p, favouritePerson);
+            updatedPersonList.add(favouritePerson);
         }
-        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personsList)));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(updatedPersonList)));
     }
     /**
      * @param personToEdit

--- a/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,8 +33,9 @@ public class FavouriteCommandTest {
         ArrayList<Index> contactIndexes = new ArrayList<>();
         contactIndexes.add(INDEX_FIRST_PERSON);
         FavouriteCommand favouriteCommand = new FavouriteCommand(contactIndexes);
+        personToFavourite = personToFavourite.setFavouritePerson();
         String expectedMessage = String.format(FavouriteCommand.MESSAGE_SUCCESS,
-            Messages.format(personToFavourite));
+            Messages.format(List.of(personToFavourite)));
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.favouritePerson(personToFavourite);
         assertCommandSuccess(favouriteCommand, model, expectedMessage, expectedModel);


### PR DESCRIPTION
## Issues
previously tags and favourite was jumbled up in the message format.
previously using favourite command still displays user favourite as false.
closes #223 and closes #188
## How to replicate
1. ensure contact 1 is not favourited yet
2. `favourite c/1`

![image](https://github.com/user-attachments/assets/960d3a8d-0406-4669-9d81-a260c89812d8)