### PR TITLE
UI bug fix for commands not correctly updating index and details

### DIFF
--- a/src/main/java/seedu/address/model/schedule/SameWeekAsDatePredicate.java
+++ b/src/main/java/seedu/address/model/schedule/SameWeekAsDatePredicate.java
@@ -26,7 +26,8 @@ public class SameWeekAsDatePredicate implements Predicate<Meeting> {
     @Override
     public boolean test(Meeting meeting) {
         return date.get(weekfields.weekOfWeekBasedYear())
-                == meeting.getMeetingDate().get(weekfields.weekOfWeekBasedYear());
+                == meeting.getMeetingDate().get(weekfields.weekOfWeekBasedYear())
+                && date.getYear() == meeting.getMeetingDate().getYear();
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -187,6 +187,7 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            weeklySchedulePanel.updateSchedulePanel();
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/calendar/WeeklySchedulePanel.java
+++ b/src/main/java/seedu/address/ui/calendar/WeeklySchedulePanel.java
@@ -42,7 +42,10 @@ public class WeeklySchedulePanel extends UiPart<Region> {
         weekHeader.textProperty().bind(dateToDisplay);
         weeklyCalendarView.setItems(dailyScheduleOfWeek);
         weeklyCalendarView.setCellFactory(listView -> new WeeklySchedulePanel.CalendarListViewCell());
+    }
 
+    public void updateSchedulePanel() {
+        weeklyCalendarView.refresh();
     }
 
     /**
@@ -50,14 +53,14 @@ public class WeeklySchedulePanel extends UiPart<Region> {
      */
     class CalendarListViewCell extends ListCell<ObservableList<Meeting>> {
         @Override
-        protected void updateItem(ObservableList<Meeting> meeting, boolean empty) {
-            super.updateItem(meeting, empty);
+        protected void updateItem(ObservableList<Meeting> schedule, boolean empty) {
+            super.updateItem(schedule, empty);
             int i = getIndex() + 1;
-            if (empty || meeting == null) {
+            if (empty || schedule == null) {
                 setGraphic(null);
                 setText(null);
             } else {
-                FilteredList<Meeting> dailySchedule = new FilteredList<>(meeting);
+                FilteredList<Meeting> dailySchedule = new FilteredList<>(schedule);
                 dailySchedule.setPredicate(m -> m.getMeetingDate().getDayOfWeek().getValue() == i);
                 setGraphic(new DailySchedulePanel(dailySchedule, personList, getIndex() + 1).getRoot());
             }

--- a/src/test/java/seedu/address/model/schedule/SameWeekAsDatePredicateTest.java
+++ b/src/test/java/seedu/address/model/schedule/SameWeekAsDatePredicateTest.java
@@ -38,6 +38,10 @@ public class SameWeekAsDatePredicateTest {
         SameWeekAsDatePredicate differentPredicate = new SameWeekAsDatePredicate(LocalDate
                 .parse("2024-10-11"));
         assertFalse(firstPredicate.equals(differentPredicate));
+        // different year -> returns false
+        SameWeekAsDatePredicate differentYearPredicate = new SameWeekAsDatePredicate(LocalDate
+                .parse("2050-10-11"));
+        assertFalse(firstPredicate.equals(differentYearPredicate));
     }
 
     @Test


### PR DESCRIPTION
closes issues #189, #202, #217, #222, #242, #258

## Changes to Logic
Changes to SameWeekAsDatePredicate:
- Test for the predicate to now include a check for same year
- Address issue #202 where meetings with same date but different years are being shown on the schedule
- Test coverage is also included

## Changes to UI Components
Changes to WeeklySchedulePanel:
- To include a function to refresh the ListView in order to show any updates made to any of the meetings
- Address issue #189 #217 

Changes to MainWindow:
- To refresh the Schedule UI whenever a command is run to ensure that data is being properly reflected
- Addresses issue #222 #242 #258 

## Prior Implementation Error
Though there is a work around the issues where the UI is not directly updated by using either the `see` command or `list-schedule` command, however we deem this to be a bug instead of a Feature Flaw. 

In milestone v1.5, the UI components are being passed an exact copy of the original schedule as an observable list of observable list, thus when there are any changes being made, the whole UI component for the schedule should have been re rendered and thus accurate. However this was not the case, causing these bugs. 

Though an interesting point was that when the Meeting UI are clicked on and selected, all the data of the meetings within that specific day will also be updated.  

The solution to this is to manually call a refresh of the ListView whenever a command is ran.
